### PR TITLE
Fix py-cpuinfo key error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+**/.idea

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="system_info",
-    version="2.0.0",
+    version="2.0.1",
     author="Suhanna CH",
     author_email="suhanna52@gmail.com",
     description="Package for finding system hardware specifications",

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
-    install_requires=['py-cpuinfo', 'psutil'],
+    install_requires=['py-cpuinfo>=6.0.0', 'psutil'],
 )

--- a/system_info/sysinfo.py
+++ b/system_info/sysinfo.py
@@ -52,7 +52,7 @@ class SystemInfo(object):
 
         cinfo = cpuinfo.get_cpu_info()
         data = {}
-        data["Processor"] = cinfo['brand']
+        data["Processor"] = cinfo['brand_raw']
         data["CPU"] = cinfo['count']
 
         if os_info.platformName() == 'Linux':


### PR DESCRIPTION
py-cpuinfo since v6.0.0 changed `branch` tag by `branch_raw` thwoing the following error:

```cmd
"D:\Program Files (x86)\Python36-32\python.exe" D:/GIT/System_info/test.py
Traceback (most recent call last):
  File "D:/GIT/System_info/test.py", line 1, in <module>
    from system_info import sysinfo
  File "D:\GIT\System_info\system_info\sysinfo.py", line 230, in <module>
    sysInfo = os_info.systemSpec()
  File "D:\GIT\System_info\system_info\sysinfo.py", line 55, in systemSpec
    data["Processor"] = cinfo['brand']
KeyError: 'brand'

Process finished with exit code 1
```